### PR TITLE
Skip definitions for well known types.

### DIFF
--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -177,18 +177,20 @@ func findNestedMessagesAndEnumerations(message *descriptor.Message, reg *descrip
 		fieldType := t.GetTypeName()
 		// If the type is an empty string then it is a proto primitive
 		if fieldType != "" {
-			if _, ok := m[fieldType]; !ok {
-				msg, err := reg.LookupMsg("", fieldType)
-				if err != nil {
-					enum, err := reg.LookupEnum("", fieldType)
+			if _, ok := wktSchemas[fieldType]; !ok {
+				if _, ok := m[fieldType]; !ok {
+					msg, err := reg.LookupMsg("", fieldType)
 					if err != nil {
-						panic(err)
+						enum, err := reg.LookupEnum("", fieldType)
+						if err != nil {
+							panic(err)
+						}
+						e[fieldType] = enum
+						continue
 					}
-					e[fieldType] = enum
-					continue
+					m[fieldType] = msg
+					findNestedMessagesAndEnumerations(msg, reg, m, e)
 				}
-				m[fieldType] = msg
-				findNestedMessagesAndEnumerations(msg, reg, m, e)
 			}
 		}
 	}


### PR DESCRIPTION
It seems that definitions of swagger.json for well known types are not necessary because well known types are already mapped to swagger's primitive types.

Could you confirm this?