### PR TITLE
Update template.go

### DIFF
--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -41,12 +41,11 @@ var wktSchemas = map[string]schemaCore{
 		Format: "int64",
 	},
 	".google.protobuf.Int64Value": schemaCore{
-		Type:   "string",
+		Type:   "integer",
 		Format: "int64",
 	},
 	".google.protobuf.UInt64Value": schemaCore{
-		Type:   "string",
-		Format: "uint64",
+		Type:   "integer",
 	},
 	".google.protobuf.FloatValue": schemaCore{
 		Type:   "number",


### PR DESCRIPTION
Closes #20 

- int64 is a valid javascript integer type
- uint64 is an integer type, but it doesn't have a defined format as per spec (https://swagger.io/docs/specification/data-models/data-types/)

I'm aware that the Swagger spec (or JS runtimes) don't support uint64, but as far as the spec goes, encoding shouldn't be "coalesced" to a string type. I just dropped the "format", as it's undefined behavior.